### PR TITLE
Fixes #7 Startup Date/Time Filter

### DIFF
--- a/example.env
+++ b/example.env
@@ -23,6 +23,11 @@ MIRROR_REST=testnet.mirrornode.hedera.com
 # The system supports subscribing to only one topic at a time.
 HCS_TOPIC=0.0.30853892
 
+# Optional starting HAPI Epoch Date & Time.  The server will only
+# process HCS messages occurring after the date & time specified
+# in this variable.
+HCS_START_DATE=1651605938.242721000
+
 # The ID of the Hedera Token that shall be used for determining 
 # voting weights.  Only ballots that use this token for weights
 # will be injested by the system.

--- a/server.yml
+++ b/server.yml
@@ -12,3 +12,4 @@ services:
       - MIRROR_REST=${MIRROR_REST}
       - HCS_TOPIC=${HCS_TOPIC}
       - HTS_TOKEN=${HTS_TOKEN}
+      - HCS_START_DATE=${HCS_START_DATE}

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "governance-api",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Ballot Governance Aggregator",
   "author": "Calaxy, Inc.",
   "private": true,

--- a/server/sample.env
+++ b/server/sample.env
@@ -21,3 +21,15 @@ HCS_TOPIC=0.0.30853892
 # voting weights.  Only ballots that use this token for weights
 # will be injested by the system.
 HTS_TOKEN=0.0.30963729
+
+# Optional starting HAPI Epoch Date & Time.  The server will only
+# process HCS messages occurring after the date & time specified
+# in this variable.  If this variable is missing, then the
+# entirety of the HCS message stream will be replayed during
+# startup.  This feature can be enabled to reduce the clutter of
+# displaying past/out-of-date proposals if desired by the
+# organization hosting this instance of the governance tool.
+# Please note that votes cast after this start date for proposals
+# defined before this start date will not be considered valid and
+# logged as invalid in the server logs.
+HCS_START_DATE=1656606000.000000

--- a/server/src/app.controller.ts
+++ b/server/src/app.controller.ts
@@ -36,6 +36,7 @@ export class AppController {
 			mirrorRest: this.config.mirrorRest,
 			htsToken: this.tokenInfo,
 			hcsTopic: this.config.hcsTopic,
+			hcsStartDate: this.config.hcsStartDate,			
 			lastUpdated: this.dataService.getLastUpdated(),
 			version: process.env.npm_package_version || 'unknown',
 		};

--- a/server/src/services/hcs-message-processing.service.ts
+++ b/server/src/services/hcs-message-processing.service.ts
@@ -111,6 +111,17 @@ export class HcsMessageProcessingService {
 		this.currentTask = thisHeartbeat = thisTask();
 	}
 	/**
+	 * When called, updates the data service with the specified timestamp,
+	 * essentially jumping ahead in time.  This exists to support the feature
+	 * where the service can ignore proposal ballots before a specified
+	 * startup moment in time.
+	 *
+	 * @param timestamp the HAPI Epoch encoded startup timestamp.
+	 */
+	setStartupTimestamp(timestamp: string) {
+		this.dataService.setLastUpdated(timestamp);
+	}
+	/**
 	 * Internal method for processing a raw HCS native message.
 	 * If the message passes initial validation checks it is forwarded
 	 * to the appropriate specialized processor.

--- a/server/src/util/epoch.ts
+++ b/server/src/util/epoch.ts
@@ -1,3 +1,5 @@
+import * as proto from '@hashgraph/proto';
+import * as Long from 'long';
 /**
  * Converts a JavaScript `Date` into Hedera epoch format (0000.0000).
  *
@@ -13,4 +15,20 @@ export function epochFromDate(date: Date | undefined): string | undefined {
 		return `${seconds}.${nanoseconds}`;
 	}
 	return undefined;
+}
+/**
+ * Converts a HAPI epoch date string into a protobuf ITimestamp
+ *
+ * @param timestamp the string representation of the HAPI epic timestamp.
+ *
+ * @returns an ITimestamp, either that value represented by a valid timestamp,
+ * or the 'null' equivalent.
+ */
+export function epochToTimestamp(timestamp: string): proto.proto.ITimestamp {
+	if (timestamp) {
+		const [secondsAsNumber, nanos] = timestamp.split('.').map((v) => parseInt(v, 10));
+		const seconds = Long.fromNumber(secondsAsNumber);
+		return { seconds, nanos };
+	}
+	return { seconds: null };
 }

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "governance-app",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",

--- a/webapp/src/models/info.ts
+++ b/webapp/src/models/info.ts
@@ -43,6 +43,10 @@ export interface NetworkInfo {
    */
   hcsTopic: string;
   /**
+   * If configured, the startup date & time filter for processing messages.
+   */
+  hcsStartDate: string;
+  /**
    * The web software user interface version.
    */
   uiVersion: string;
@@ -68,6 +72,7 @@ export const network = ref<NetworkInfo>({
   mirrorGrpc: "",
   mirrorRest: "",
   hcsTopic: "",
+  hcsStartDate: "",
   uiVersion: __APP_VERSION__,
   apiVersion: "",
 });
@@ -86,6 +91,7 @@ export async function refreshInfo(): Promise<void> {
     mirrorGrpc: json.mirrorGrpc,
     mirrorRest: json.mirrorRest,
     hcsTopic: json.hcsTopic,
+    hcsStartDate: json.hcsStartDate,
     uiVersion: __APP_VERSION__,
     apiVersion: json.version,
   };

--- a/webapp/src/views/AboutView.vue
+++ b/webapp/src/views/AboutView.vue
@@ -24,6 +24,9 @@ onMounted(async () => {
       <dd>
         <EpochDateDisplay :value="lastUpdated"></EpochDateDisplay>
       </dd>
+      <template v-if="network.hcsStartDate">
+        <dd>(Proposals created before <EpochDateDisplay class="inline" :value="network.hcsStartDate"></EpochDateDisplay> are not included)</dd>
+      </template>
       <dt>Hedera Network</dt>
       <dd>{{ network.network }}</dd>
       <dt>Source Mirror Node</dt>
@@ -93,5 +96,8 @@ h2 {
     border-right: none;
     border-radius: 0;
   }
+}
+.inline {
+  display: inline-block;
 }
 </style>


### PR DESCRIPTION
Added an additional configuration option allowing the deployer to
specify a date & time at which the startup replay of HCS messages
should begin.  This makes it possible to ignore old and outdated
proposals inside a given HCS consensus message stream.