### PR TITLE
Fixes #15  Connect Wallet Dialog Issue

### DIFF
--- a/webapp/src/assets/base.css
+++ b/webapp/src/assets/base.css
@@ -197,9 +197,11 @@ a.back:hover {
 	dialog {
 		border-radius: 0;
 		border: none;
-		width: 100vw;
-		height: 100vh;
-		max-width: none;
-		max-height: none;
+		width: 100%;
+		height: 100%;
 	}
+	dialog::backdrop {
+		opacity: 1;
+		background-color: #111820;
+	}	
 }


### PR DESCRIPTION
Turns out, it is problematic to override certain
user-agent default css configurations for dialogs.
Attempted to use different styles to achieve the
same "full page" result of the dialog without
running afoul of in-built user-agent css rules for
dialogs.

Additional found that since the dialog css for
the backdrop appears in an unusual place in
the cascade, the definition of --cds variables
does not apply so the background colors must
be hard-coded with direct values aka #000000.