### PR TITLE
Fixes #18 "active state" input UI clipped

### DIFF
--- a/webapp/src/assets/base.css
+++ b/webapp/src/assets/base.css
@@ -136,7 +136,7 @@ select {
 input:focus,
 select:focus {
 	outline: none;
-	box-shadow: 0px 0px 0px 1px var(--cds-nl-500), 0px 0px 0px 4px var(--cds-nd-600);
+	box-shadow: inset 0px 0px 0px 3px var(--cds-nd-600), inset 0px 0px 0px 4px var(--cds-nl-500);
 }
 
 input::placeholder {


### PR DESCRIPTION
Changed the UI "active" dropdown shadow to a
CSS inset implementation to avoid clipping of the
dropshadow by the parent element.

If drowshadown is preferred, we can possibly wrap the
inputs inside an additional <div> with extra padding to
accomidate the shadow outside the alignment of the
desired margin.