### PR TITLE
Fixes #24 Errant Dialog display on Safari

### DIFF
--- a/webapp/src/assets/base.css
+++ b/webapp/src/assets/base.css
@@ -152,6 +152,10 @@ dialog {
 	border: 1px solid var(--cds-nd-600);
 }
 
+dialog:not([open]) {
+    display: none;
+}
+
 dialog>header {
 	display: grid;
 	grid-template-columns: 1fr max-content;

--- a/webapp/src/components/MainAside.vue
+++ b/webapp/src/components/MainAside.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
+import { ref } from "vue";
 import { RouterLink } from "vue-router";
+
+const supportsDialog = ref<boolean>(typeof HTMLDialogElement === 'function');
 </script>
 
 <template>
@@ -7,7 +10,7 @@ import { RouterLink } from "vue-router";
     <header>Calaxy - $CLXY</header>
     <nav>
       <RouterLink to="/">Proposals</RouterLink>
-      <RouterLink to="/new">New Proposal</RouterLink>
+      <RouterLink v-if="supportsDialog" to="/new">New Proposal</RouterLink>
       <RouterLink to="/about">About</RouterLink>
     </nav>
   </aside>

--- a/webapp/src/components/MainHeader.vue
+++ b/webapp/src/components/MainHeader.vue
@@ -12,6 +12,7 @@ import {
 
 const dialog = ref<any>();
 const paringString = ref<string>();
+const supportsDialog = ref<boolean>(typeof HTMLDialogElement === 'function');
 
 async function onConnectWallet() {
   dialog.value.showModal();
@@ -57,7 +58,11 @@ onMounted(() => {
 
 <template>
   <header class="main">
-    <button v-if="currentGateway === GatewayProvider.CopyAndPaste" v-on:click="onConnectWallet">
+    <button v-if="!supportsDialog" disabled>
+      <span class="btn-icon">RO</span>
+      <span class="btn-text">Read Only</span>
+    </button>
+    <button v-else-if="currentGateway === GatewayProvider.CopyAndPaste" v-on:click="onConnectWallet">
       <CopyPasteIcon />
       <span class="btn-text">Copy / Paste JSON</span>
     </button>

--- a/webapp/src/components/NavigationBar.vue
+++ b/webapp/src/components/NavigationBar.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
+import { ref } from "vue";
 import { RouterLink } from "vue-router";
+
+const supportsDialog = ref<boolean>(typeof HTMLDialogElement === 'function');
+
 </script>
 
 <template>
   <nav>
     <RouterLink to="/">Proposals</RouterLink>
-    <RouterLink to="/new">New Proposal</RouterLink>
+    <RouterLink v-if="supportsDialog" to="/new">New Proposal</RouterLink>
     <RouterLink to="/about">About</RouterLink>
   </nav>
 </template>


### PR DESCRIPTION
This commit attempts to mitigate the display issues
associated with using an old version of Safari browser.
Old versions of Safari do not support the <dialog> element.
This results in the dialog contents accidentally displaying on
initial load.  This fix mitgates (but does not fully solve) the
problem.

If the browser does not support the <dialog> element, the
site will fall back to "Read Only" mode, only displaying
information, not presenting UI to update information.
This is because write operations almost all utilize dialog
interactions.

Since the current version of the Safari browser >= 15.4
supports the <dialog> element, this choice was taken instead
of polyfilling the dialog functionality with an additional
javascript framework/dependency.  Chrome based browsers
fully support <dialog> at this time.