### PR TITLE
fixing copy button's box shadow

### DIFF
--- a/webapp/src/components/MainHeader.vue
+++ b/webapp/src/components/MainHeader.vue
@@ -203,9 +203,11 @@ header.main > button {
 }
 
 .description {
-  margin-bottom: 1rem;
+  padding-bottom: 1rem;
   overflow-x: hidden;
   overflow-y: auto;
+  padding-right: 10px;
+  margin-right: -10px;
 }
 
 .description dl {


### PR DESCRIPTION
This request includes one commit with the intention to close issue #30. 

Since the button's box shadow is being cutoff by the div's border, I added padding on the bottom (in place of a bottom margin) and on the right side (accompanied with a negative right margin). The result keeps the description div in the same place but allows for the button's box shadow to not be obstructed. 
![Screen Shot 2022-10-28 at 2 22 14 PM](https://user-images.githubusercontent.com/92487408/198735087-5d2c4fec-5f3d-47aa-92bd-fabfe7fe5544.png)
![Screen Shot 2022-10-28 at 2 22 25 PM](https://user-images.githubusercontent.com/92487408/198735092-a1abde56-6fa7-400e-ab3a-1b8c3a7a7609.png)
